### PR TITLE
Fix VerifyError on some environments

### DIFF
--- a/src/pogonos/core.cljc
+++ b/src/pogonos/core.cljc
@@ -7,7 +7,7 @@
             #?(:clj [pogonos.partials :as partials])
             [pogonos.reader :as reader]
             [pogonos.render :as render])
-  #?(:clj (:import [java.io Closeable FileNotFoundException])))
+  #?(:clj (:import [java.io FileNotFoundException])))
 
 (def ^:private default-options (atom nil))
 
@@ -66,7 +66,7 @@
       (let [f (io/as-file file)]
         (if (.exists f)
           (let [opts (fixup-options opts partials/file-partials)]
-            (with-open [in ^Closeable (reader/make-file-reader f)]
+            (with-open [in (reader/make-file-reader f)]
               (parse-input in opts)))
           (throw (FileNotFoundException. (.getName f))))))))
 
@@ -81,7 +81,7 @@
      ([res opts]
       (if-let [res (io/resource res)]
         (let [opts (fixup-options opts partials/resource-partials)]
-          (with-open [in ^Closeable (reader/make-file-reader res)]
+          (with-open [in (reader/make-file-reader res)]
             (parse-input in opts)))
         (throw (FileNotFoundException. res))))))
 
@@ -141,7 +141,7 @@
           (let [opts (-> opts
                          (fixup-options partials/file-partials)
                          (assoc :source (.getName f)))]
-            (with-open [in ^Closeable (reader/make-file-reader f)]
+            (with-open [in (reader/make-file-reader f)]
               (render-input in data opts)))
           (throw (FileNotFoundException. (.getName f))))))))
 
@@ -157,7 +157,7 @@
       (if-let [res (io/resource res)]
         (let [opts (cond-> (fixup-options opts partials/resource-partials)
                      (string? res) (assoc :source res))]
-          (with-open [in ^Closeable (reader/make-file-reader res)]
+          (with-open [in (reader/make-file-reader res)]
             (render-input in data opts)))
         (throw (FileNotFoundException. res))))))
 

--- a/src/pogonos/reader.cljc
+++ b/src/pogonos/reader.cljc
@@ -4,7 +4,7 @@
             #?(:clj [clojure.java.io :as io])
             [pogonos.protocols :as proto]
             [pogonos.strings :as pstr])
-  #?(:clj (:import [java.io Reader Closeable])))
+  #?(:clj (:import [java.io Reader])))
 
 (defn ->reader [x]
   (if (satisfies? proto/IReader x)
@@ -24,7 +24,7 @@
         ret)))
   (close [this]))
 
-(defn make-string-reader [s]
+(defn ^StringReader make-string-reader [s]
   (StringReader. s 0))
 
 (extend-protocol proto/ToReader
@@ -61,12 +61,11 @@
                (do (.append sb buf offset (- size offset))
                    (set! offset size)
                    (recur sb)))))))
-     Closeable
      (close [this]
        (.close reader))))
 
 #?(:clj
-   (defn make-file-reader [file]
+   (defn ^FileReader make-file-reader [file]
      (FileReader. (io/reader file) (char-array 256) 0 0)))
 
 #?(:clj

--- a/test/pogonos/reader_test.cljc
+++ b/test/pogonos/reader_test.cljc
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer [deftest is testing]]
             [pogonos.protocols :as proto]
             [pogonos.reader :as reader])
-  #?(:clj (:import [java.io Closeable File])))
+  #?(:clj
+     (:import [java.io File]
+              [pogonos.reader FileReader])))
 
 (deftest string-reader-test
   (let [r (reader/make-string-reader "")]
@@ -28,7 +30,7 @@
     (is (nil? (proto/read-line r)))))
 
 #?(:clj
-   (defn- ^Closeable make-file-reader [content]
+   (defn- ^FileReader make-file-reader [content]
      (-> (doto (File/createTempFile "tmp" nil)
            (spit content))
          (reader/make-file-reader))))
@@ -57,7 +59,7 @@
        (is (= "baz\n" (proto/read-line r)))
        (is (nil? (proto/read-line r))))))
 
-(defn- ^Closeable make-line-buffering-reader [content]
+(defn- make-line-buffering-reader [content]
   (reader/make-line-buffering-reader (reader/make-string-reader content)))
 
 (deftest line-buffering-reader-test


### PR DESCRIPTION
When I load `pogonos.reader` in the Clojure CLI REPL on JVM 14, I run into a `VerifyError` like the following:

```clojure
$ clj
Clojure 1.10.1
user=> (require 'pogonos.reader)
Syntax error (VerifyError) compiling new at (pogonos/reader.cljc:36:4).
Operand stack underflow
Exception Details:
  Location:
    pogonos/reader/FileReader.close()Ljava/lang/Object; @6: areturn
  Reason:
    Attempt to pop empty stack.
  Current Frame:
    bci: @6
    flags: { }
    locals: { 'pogonos/reader/FileReader' }
    stack: { }
  Bytecode:
    0x0000000: 2ab9 0090 0100 b0

user=>
```

The same goes for Clojure CLI on JVM 8 and `lein repl` on JVM 14, but NOT for `lein repl` on JVM 8.

I'm not really sure what is exactly causing this (maybe the difference of classloaders and/or some change in the bytecode verification logic matters?), but after digging into it for a while, I figured out this happens if the reader impls implement `java.io.Closeable#close()` (which overloads `pogonos.protocols/IReader#close()`).

My first design decision for making the readers implement `java.io.Closeable` was just for the user's convenience. Now, however, I don't think It's worthwhile to do so because:

- In most cases, we, as a user, don't need to handle the readers directly
- Even when we really do, we can use `pogonos.protocols/IReader#close()` instead of `java.io.Closeable#close()`

So, this PR removes the `java.io.Closeable` implementation from the readers to work around the `VerifyError`. This really is a breaking change, but its impact won't be so significant for the reasons above.