### PR TITLE
Fix shadow-cljs warnings that complain about marker protocol

### DIFF
--- a/src/pogonos/core.cljc
+++ b/src/pogonos/core.cljc
@@ -34,7 +34,7 @@
   ([in opts]
    (let [buf (parse/make-node-buffer)
          out (fn [x]
-               (when-not (satisfies? nodes/Invisible x)
+               (when (nodes/visible? x)
                  (buf x)))
          opts (fixup-options opts #?(:clj partials/resource-partials))]
      (parse/parse in out opts)

--- a/src/pogonos/nodes.cljc
+++ b/src/pogonos/nodes.cljc
@@ -1,6 +1,11 @@
 (ns pogonos.nodes)
 
-(defprotocol Invisible)
+(defprotocol IVisibility
+  (visible? [this]))
+
+(extend-protocol IVisibility
+  #?(:clj Object :cljs default)
+  (visible? [thihs] true))
 
 (defrecord Root [body])
 
@@ -17,7 +22,9 @@
 (defrecord Partial [name indent])
 
 (defrecord Comment [body]
-  Invisible)
+  IVisibility
+  (visible? [this] false))
 
 (defrecord SetDelimiter [open close]
-  Invisible)
+  IVisibility
+  (visible? [this] false))


### PR DESCRIPTION
Although Pogonos now does not officially support [shadow-cljs](https://github.com/thheller/shadow-cljs), while I was trying it privately, it told me there were some infer warnings, which `clj -Rcljs -m cljs.main` never ever complained:

```
------ WARNING #1 - :infer-warning ---------------------------------------------
 File: /path/to/pogonos/src/pogonos/nodes.cljc:19:1
--------------------------------------------------------------------------------
  16 |
  17 | (defrecord Partial [name indent])
  18 |
  19 | (defrecord Comment [body]
-------^------------------------------------------------------------------------
 Cannot infer target type in expression (. (. Comment -prototype) -pogonos$nodes$Invisible$)
--------------------------------------------------------------------------------
  20 |   Invisible)
  21 |
  22 | (defrecord SetDelimiter [open close]
  23 |   Invisible)
--------------------------------------------------------------------------------

------ WARNING #2 - :infer-warning ---------------------------------------------
 File: /path/to/pogonos/src/pogonos/nodes.cljc:22:1
--------------------------------------------------------------------------------
  19 | (defrecord Comment [body]
  20 |   Invisible)
  21 |
  22 | (defrecord SetDelimiter [open close]
-------^------------------------------------------------------------------------
 Cannot infer target type in expression (. (. SetDelimiter -prototype) -pogonos$nodes$Invisible$)
--------------------------------------------------------------------------------
  23 |   Invisible)
  24 |
--------------------------------------------------------------------------------

------ WARNING #3 - :infer-warning ---------------------------------------------
 File: /path/to/pogonos/src/pogonos/core.cljc:37:26
--------------------------------------------------------------------------------
  34 |   ([in opts]
  35 |    (let [buf (parse/make-node-buffer)
  36 |          out (fn [x]
  37 |                (when-not (satisfies? nodes/Invisible x)
--------------------------------^-----------------------------------------------
 Cannot infer target type in expression (. x -pogonos$nodes$Invisible$)
--------------------------------------------------------------------------------
  38 |                  (buf x)))
  39 |          opts (fixup-options opts #?(:clj partials/resource-partials))]
  40 |      (parse/parse in out opts)
  41 |      (with-meta
--------------------------------------------------------------------------------
```

Roughly, these warnings seem to complain about a marker protocol (i.e. `Invisible`). After some exploration, it turned out that removing the protocol from the two record implementations resolved the warnings.

This PR replaces the `Invisible` protocol with a new one named `IVisibility`, which has a single method. The change not only resolves the above issue, but also makes the caller code more straightforward. It is indeed a breaking change, but has almost no impact on user code, I guess.