### PR TITLE
New API to check template syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,34 @@ parsing results for templates you've ever rendered, for better performance
 of rendering. So, if you're trying to use Pogonos where the rendering
 performance matters much, you may have to cache parsed templates on your own.
 
+#### `check-string` / `check-file` / `check-resource`
+
+Pogonos also provides another set of functions: `check-string`, `check-file` and `check-resource`.
+
+These functions try to parse the input template and check if the template
+contains any Mustache syntax error. If any, they will report it as an exception.
+Otherwise, they will return nil silently:
+
+```clojure
+(pg/check-string "Hello, {{name")
+;; Execution error (ExceptionInfo) at pogonos.error/error (error.cljc:52).
+;; Missing closing delimiter "}}" (1:14):
+;;
+;;   1| Hello, {{name
+;;                   ^^
+
+(pg/check-string "Hello, {{name}}!")
+;=> nil
+```
+
+The verbosity of error messages can be controlled by an option.
+See [Error messages](#error-messages) for details.
+
+What the `check-*` functions do is semantically equivalent to "parsing a template
+and discarding the parsed result". However, the `check-*` functions are generally
+more efficient than `parse-*` in this regard because the former functions do not
+actually build a syntax tree.
+
 ### Outputs
 
 An output is the way to specify where to output the rendering result.

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ parsing results for templates you've ever rendered, for better performance
 of rendering. So, if you're trying to use Pogonos where the rendering
 performance matters much, you may have to cache parsed templates on your own.
 
-#### `check-string` / `check-file` / `check-resource`
+#### `check-string` / `check-file` / `check-resource` \[`0.2.0+`\]
 
-Pogonos also provides another set of functions: `check-string`, `check-file` and `check-resource`.
+Since `0.2.0`, Pogonos also provides another set of functions: `check-string`, `check-file` and `check-resource`.
 
 These functions try to parse the input template and check if the template
 contains any Mustache syntax error. If any, they will report it as an exception.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ We will show you how to use Pogonos in this section, but if you're not too famil
 
 ### Fundamentals
 
+#### `render-string`
+
 The easiest way to use the library is to just call `render-string`:
 
 ```clojure
@@ -57,6 +59,8 @@ The function, then, will render the template and return the resulting string.
 If you'd rather write out the rendering result to somewhere, instead of
 generating a string, you can use *outputs* to specify where to output the result.
 See [Outputs](#outputs) for the details.
+
+#### `render-file` / `render-resource`
 
 `render-string` has look-alike cousins named `render-file` and `render-resource`.
 The only difference between `render-string` and those functions is that `render-string`
@@ -87,6 +91,8 @@ included in the classpath):
 ;; loads a template from a resource file on the classpath
 (pg/render-resource "sample.mustache" {:name "Rich"})
 ```
+
+#### `parse-string` / `parse-file` / `parse-resource` / `render`
 
 All the render functions mentioned above are more suitable for one-shot
 rendering. But if you want to render the same template with different contexts

--- a/src/pogonos/core.cljc
+++ b/src/pogonos/core.cljc
@@ -174,6 +174,7 @@
 
   - :suppress-verbose-errors  If set to true, suppress verbose error messages.
                               Defaults to false."
+  {:added "0.2.0"}
   ([s] (check-string s {}))
   ([s opts]
    (check-input (reader/make-string-reader s) opts)))
@@ -185,6 +186,7 @@ Throws if there is a syntax error, otherwise returns nil.
 
 Optionally takes an option map. See the docstring of `check-string` for
 the available options."
+     {:added "0.2.0"}
      ([file] (check-file file {}))
      ([file opts]
       (let [f (io/as-file file)]
@@ -199,6 +201,7 @@ the available options."
 
 Optionally takes an option map. See the docstring of `check-string` for
 the available options."
+     {:added "0.2.0"}
      ([res] (check-resource res {}))
      ([res opts]
       (if-let [res (io/resource res)]

--- a/test-resources/templates/broken.mustache
+++ b/test-resources/templates/broken.mustache
@@ -1,0 +1,1 @@
+Hello, {{name}!

--- a/test/pogonos/core_test.cljc
+++ b/test/pogonos/core_test.cljc
@@ -4,6 +4,7 @@
             [pogonos.core :as pg]))
 
 (def ^:private demo-file "templates/demo.mustache")
+(def ^:private broken-file "templates/broken.mustache")
 
 (def ^:private data
   {:header "Colors"
@@ -17,6 +18,19 @@
      (is (= (pg/parse-string (slurp (io/resource demo-file)))
             (pg/parse-file (io/as-file (io/resource demo-file)))
             (pg/parse-resource demo-file)))))
+
+(deftest check-test
+  (is (nil? (pg/check-string "Hello, {{name}}!")))
+  (is (thrown? #?(:clj Exception :cljs js/Error)
+               (pg/check-string "Hello, {{name}!")))
+  #?(:clj
+     (is (nil? (pg/check-file (io/as-file (io/resource demo-file))))))
+  #?(:clj
+     (is (thrown? Exception (pg/check-file (io/as-file (io/resource broken-file))))))
+  #?(:clj
+     (is (nil? (pg/check-resource demo-file))))
+  #?(:clj
+     (is (thrown? Exception (pg/check-resource broken-file)))))
 
 #?(:clj
    (deftest render-test


### PR DESCRIPTION
```clojure
(require '[pogonos.core :as pg])

(pg/check-string "Hello, {{name")
;; Execution error (ExceptionInfo) at pogonos.error/error (error.cljc:52).
;; Missing closing delimiter "}}" (1:14):
;;
;;   1| Hello, {{name
;;                   ^^

(pg/check-string "Hello, {{name}}!")
;=> nil
```

What the `check-*` functions do is semantically equivalent to "parsing a template and discarding the parsed result" but they are more efficient than `parse-*` because the `check-*` do not build a syntax tree to perform syntax check.