### PR TITLE
Add API for use as `-X` program or `-T` CLI tool

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
+ :tools/usage {:ns-default pogonos.api}
  :aliases {:check
            {:extra-deps
             {athos/clj-check {:git/url "https://github.com/athos/clj-check.git"

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -30,7 +30,7 @@
   (re-pattern (Pattern/quote (System/getProperty "path.separator"))))
 
 (defn- str->matcher [s]
-  (comp boolean (partial re-find (re-pattern s))))
+  (comp boolean (partial re-find (re-pattern (str s)))))
 
 (defn- check-inputs [inputs {:keys [include-regex exclude-regex] :as opts}]
   (let [include? (if include-regex

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -1,15 +1,23 @@
 (ns pogonos.api
-  (:require [pogonos.core :as pg]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [pogonos.core :as pg]
             [pogonos.output :as out]
-            [pogonos.reader :as reader]))
+            [pogonos.reader :as reader])
+  (:import [java.io PushbackReader]))
 
-(defn render [{:keys [string file resource data output] :as opts}]
-  (let [out (if output
+(defn render [{:keys [string file resource data data-file output] :as opts}]
+  (let [data (or (when data-file
+                   (with-open [r (-> (io/reader (str data-file))
+                                     PushbackReader.)]
+                     (edn/read r)))
+                 data)
+        out (if output
               (out/to-file (str output))
               (out/to-stdout))
         opts' (-> opts
                   (assoc :output out)
-                  (dissoc :string :file :resource :data))]
+                  (dissoc :string :file :resource :data :data-file))]
     (cond string (pg/render-string string data opts')
           file (pg/render-file (str file) data opts')
           resource (pg/render-resource (str resource) data opts')

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -1,0 +1,16 @@
+(ns pogonos.api
+  (:require [pogonos.core :as pg]
+            [pogonos.output :as out]
+            [pogonos.reader :as reader]))
+
+(defn render [{:keys [string file resource data output] :as opts}]
+  (let [out (if output
+              (out/to-file output)
+              (out/to-stdout))
+        opts' (-> opts
+                  (assoc :output out)
+                  (dissoc :string :file :resource :data))]
+    (cond string (pg/render-string string data opts')
+          file (pg/render-file file data opts')
+          resource (pg/render-resource resource data opts')
+          :else (pg/render-input (reader/->reader *in*) data opts'))))

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -9,7 +9,9 @@
   (:import [java.io File PushbackReader]
            [java.util.regex Pattern]))
 
-(defn render [{:keys [string file resource data data-file output] :as opts}]
+(defn render
+  {:added "0.2.0"}
+  [{:keys [string file resource data data-file output] :as opts}]
   (let [data (or (when data-file
                    (with-open [r (-> (io/reader (str data-file))
                                      PushbackReader.)]
@@ -89,6 +91,7 @@
     (str/split (str path) path-separator)))
 
 (defn check
+  {:added "0.2.0"}
   [{:keys [string file dir resource on-failure] :or {on-failure :exit} :as opts}]
   (binding [*errors* []]
     (cond string (with-error-handling opts #(pg/check-string string opts))

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -10,6 +10,21 @@
            [java.util.regex Pattern]))
 
 (defn render
+  "Renders the given Mustache template.
+
+  One of the following option can be specified as a template source:
+   - :string    Renders the given template string
+   - :file      Renders the specified template file
+   - :resource  Renders the specified template resource on the classpath
+
+  If none of these are specified, the template will be read from stdin.
+
+  The following options can also be specified:
+   - :output     Path to the output file. If not specified, the rendering result
+                 will be emitted to stdout by default.
+   - :data       Map of the values passed to the template
+   - :data-file  If specified, reads an edn map from the file specified by that
+                 path and pass it to the template"
   {:added "0.2.0"}
   [{:keys [string file resource data data-file output] :as opts}]
   (let [data (or (when data-file
@@ -91,6 +106,27 @@
     (str/split (str path) path-separator)))
 
 (defn check
+  "Checks if the given Mustache template contains any syntax error.
+
+  The following options cab be specified as a template source:
+   - :string    Checks the given template string
+   - :file      Checks the specified template file
+   - :dir       Checks the template files in the specified directory
+   - :resource  Checks the specified template resource on the classpath
+
+  If none of these are specified, the template will be read from stdin.
+
+  For the :file/:dir/:resource options, two or more files/directories/resources
+  may be specified by delimiting them with the file path separator (i.e. ':' (colon)
+  on Linux/macOS and ';' (semicolon) on Windows).
+
+  When multiple templates are checked using the :file/:dir/:resource options,
+  they can be filtered with the :include-regex and/or exclude-regex options.
+
+  The verbosity of the syntax check results may be adjusted to some extent with
+  the following options:
+   - :only-show-errors         Hides progress messages
+   - :suppress-verbose-errors  Suppresses verbose error messages"
   {:added "0.2.0"}
   [{:keys [string file dir resource on-failure] :or {on-failure :exit} :as opts}]
   (binding [*errors* []]

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -45,7 +45,7 @@
         (binding [*out* *err*]
           (println "Checking template" name)))
       (with-open [r (reader/->reader input)]
-        (pg/check-input r opts)))))
+        (pg/check-input r (assoc opts :source name))))))
 
 (defn- check-files [files opts]
   (-> (for [file files

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -1,11 +1,13 @@
 (ns pogonos.api
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [pogonos.core :as pg]
+            [pogonos.error :as error]
             [pogonos.output :as out]
-            [pogonos.reader :as reader]
-            [pogonos.error :as error])
-  (:import [java.io PushbackReader]))
+            [pogonos.reader :as reader])
+  (:import [java.io File PushbackReader]
+           [java.util.regex Pattern]))
 
 (defn render [{:keys [string file resource data data-file output] :as opts}]
   (let [data (or (when data-file
@@ -24,10 +26,21 @@
           resource (pg/render-resource (str resource) data opts')
           :else (pg/render-input (reader/->reader *in*) data opts'))))
 
-(defn check [{:keys [string file resource] :as opts}]
+(def ^:private ^:const path-separator
+  (re-pattern (Pattern/quote (System/getProperty "path.separator"))))
+
+(defn- check-files [dir opts]
+  (let [dirs (str/split dir path-separator)]
+    (doseq [dir dirs
+            ^File file (file-seq (io/file dir))
+            :when (.isFile file)]
+      (pg/check-file file opts))))
+
+(defn check [{:keys [string file dir resource] :as opts}]
   (try
     (cond string (pg/check-string string opts)
           file (pg/check-file (str file) opts)
+          dir (check-files (str dir) opts)
           resource (pg/check-resource (str resource) opts)
           :else (pg/check-input (reader/->reader *in*) opts))
     (catch Exception e

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -5,12 +5,12 @@
 
 (defn render [{:keys [string file resource data output] :as opts}]
   (let [out (if output
-              (out/to-file output)
+              (out/to-file (str output))
               (out/to-stdout))
         opts' (-> opts
                   (assoc :output out)
                   (dissoc :string :file :resource :data))]
     (cond string (pg/render-string string data opts')
-          file (pg/render-file file data opts')
-          resource (pg/render-resource resource data opts')
+          file (pg/render-file (str file) data opts')
+          resource (pg/render-resource (str resource) data opts')
           :else (pg/render-input (reader/->reader *in*) data opts'))))

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -43,7 +43,7 @@
     (f)
     (catch Exception e
       (if (::error/type (ex-data e))
-        (do (when-not (:quiet opts)
+        (do (when (or (not (:quiet opts)) (:only-show-errors opts))
               (binding [*out* *err*]
                 (println "[ERROR]" (ex-message e))))
             (set! *errors* (conj *errors* e)))
@@ -58,7 +58,7 @@
                    (constantly false))]
     (doseq [{:keys [name input]} inputs
             :when (and (include? name) (not (exclude? name)))]
-      (when-not (:quiet opts)
+      (when (and (not (:quiet opts)) (not (:only-show-errors opts)))
         (binding [*out* *err*]
           (println "Checking template" name)))
       (with-open [r (reader/->reader input)]

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -91,7 +91,8 @@
     (mapv str path)
     (str/split (str path) path-separator)))
 
-(defn check [{:keys [string file dir resource] :as opts}]
+(defn check
+  [{:keys [string file dir resource on-failure] :or {on-failure :exit} :as opts}]
   (binding [*errors* []]
     (cond string (with-error-handling #(pg/check-string string opts))
           file (check-files (split-path file) opts)
@@ -100,4 +101,7 @@
           :else (with-error-handling
                   #(pg/check-input (reader/->reader *in*) opts)))
     (when (seq *errors*)
-      (System/exit 1))))
+      (case on-failure
+        :exit (System/exit 1)
+        :throw (throw (ex-info "Template checking failed" {:errors *errors*}))
+        nil))))

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -49,7 +49,10 @@
   (try
     (cond string (pg/check-string string opts)
           file (pg/check-file (str file) opts)
-          dir (check-files (str dir) opts)
+          dir (check-files (if (sequential? dir)
+                             (mapv str dir)
+                             (str/split (str dir) path-separator))
+                           opts)
           resource (pg/check-resource (str resource) opts)
           :else (pg/check-input (reader/->reader *in*) opts))
     (catch Exception e

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -3,7 +3,8 @@
             [clojure.java.io :as io]
             [pogonos.core :as pg]
             [pogonos.output :as out]
-            [pogonos.reader :as reader])
+            [pogonos.reader :as reader]
+            [pogonos.error :as error])
   (:import [java.io PushbackReader]))
 
 (defn render [{:keys [string file resource data data-file output] :as opts}]
@@ -22,3 +23,15 @@
           file (pg/render-file (str file) data opts')
           resource (pg/render-resource (str resource) data opts')
           :else (pg/render-input (reader/->reader *in*) data opts'))))
+
+(defn check [{:keys [string file resource] :as opts}]
+  (try
+    (cond string (pg/check-string string opts)
+          file (pg/check-file (str file) opts)
+          resource (pg/check-resource (str resource) opts)
+          :else (pg/check-input (reader/->reader *in*) opts))
+    (catch Exception e
+      (if (::error/type (ex-data e))
+        (throw (ex-info (str "Template parsing failed: " (ex-message e))
+                        (ex-data e)))
+        (throw e)))))

--- a/test-resources/data.edn
+++ b/test-resources/data.edn
@@ -1,0 +1,1 @@
+{:name "Clojurian"}

--- a/test-resources/templates/hello.mustache
+++ b/test-resources/templates/hello.mustache
@@ -1,0 +1,1 @@
+Hello, {{name}}!

--- a/test/pogonos/api_test.clj
+++ b/test/pogonos/api_test.clj
@@ -1,0 +1,122 @@
+(ns pogonos.api-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is are testing]]
+            [pogonos.api :as api]
+            [clojure.string :as str]))
+
+(defn test-file [path]
+  (str (io/file (io/resource path))))
+
+(deftest render-test
+  (are [opts expected] (= expected (with-out-str (api/render opts)))
+    {:string "Hello, {{name}}!" :data {:name "Clojurian"}}
+    "Hello, Clojurian!"
+
+    {:file (test-file "templates/hello.mustache")
+     :data-file (test-file "data.edn")}
+    "Hello, Clojurian!\n"
+
+    {:resource "templates/hello.mustache" :data {:name "Clojurian"}}
+    "Hello, Clojurian!\n")
+  (is (= "Hello, Clojurian!"
+         (with-out-str
+           (with-in-str "Hello, {{name}}!"
+             (api/render {:data {:name "Clojurian"}}))))))
+
+(defn- with-stderr-lines [f]
+  (-> (with-out-str
+        (binding [*err* *out*]
+          (f)))
+      (str/split #"\n")))
+
+(defn- join-paths [& paths]
+  (str/join (System/getProperty "path.separator") paths))
+
+(deftest check-test
+  (testing "basic use cases"
+    (is (nil? (api/check {:string "{{foo}}" :quiet true})))
+    (is (thrown? Exception
+                 (api/check {:string "{{foo" :quiet true :on-failure :throw})))
+    (is (nil? (api/check {:file (test-file "templates/hello.mustache")
+                          :quiet true})))
+    (is (thrown? Exception
+                 (api/check {:file (test-file "templates/broken.mustache")
+                             :quiet true :on-failure :throw})))
+    (is (nil? (api/check {:resource "templates/hello.mustache" :quiet true})))
+    (is (thrown? Exception
+                 (api/check {:resource "templates/broken.mustache"
+                             :quiet true :on-failure :throw})))
+    (is (nil? (with-in-str "{{foo}}" (api/check {:quiet true}))))
+    (is (thrown? Exception
+                 (with-in-str "{{foo"
+                   (api/check {:quiet true :on-failure :throw})))))
+  (testing "bulk check"
+    (testing "files"
+      (is (= [(str "Checking template " (test-file "templates/hello.mustache"))
+              (str "Checking template " (test-file "templates/main.mustache"))]
+             (with-stderr-lines
+               #(api/check {:file [(test-file "templates/hello.mustache")
+                                   (test-file "templates/main.mustache")]}))))
+      (let [lines (with-stderr-lines
+                    #(api/check {:file (join-paths
+                                        (test-file "templates/hello.mustache")
+                                        (test-file "templates/broken.mustache"))
+                                 :on-failure nil
+                                 :suppress-verbose-errors true}))]
+        (is (= (count lines) 3))
+        (is (= (str "Checking template " (test-file "templates/hello.mustache"))
+               (nth lines 0)))
+        (is (= (str "Checking template " (test-file "templates/broken.mustache"))
+               (nth lines 1)))
+        (is (str/starts-with? (nth lines 2) "[ERROR]"))))
+    (testing "resources"
+      (is (= ["Checking template templates/main.mustache"
+              "Checking template templates/node.mustache"]
+             (with-stderr-lines
+               #(api/check {:resource ["templates/main.mustache"
+                                       "templates/node.mustache"]}))))
+      (let [lines (with-stderr-lines
+                    #(api/check {:resource (join-paths "templates/broken.mustache"
+                                                       "templates/hello.mustache")
+                                 :on-failure nil
+                                 :suppress-verbose-errors true}))]
+        (is (= (count lines) 3))
+        (is (= "Checking template templates/broken.mustache" (nth lines 0)))
+        (is (str/starts-with? (nth lines 1) "[ERROR]"))
+        (is (= "Checking template templates/hello.mustache" (nth lines 2)))))
+    (testing "dirs"
+      (let [lines (sort
+                   (with-stderr-lines
+                     #(api/check {:dir (test-file "templates")
+                                  :on-failure nil
+                                  :suppress-verbose-errors true})))]
+        (is (= [(str "Checking template " (test-file "templates/broken.mustache"))
+                (str "Checking template " (test-file "templates/demo.mustache"))
+                (str "Checking template " (test-file "templates/hello.mustache"))
+                (str "Checking template " (test-file "templates/main.mustache"))
+                (str "Checking template " (test-file "templates/node.mustache"))]
+               (butlast lines)))
+        (is (str/starts-with? (last lines) "[ERROR]")))
+      (let [lines (with-stderr-lines
+                    #(api/check {:dir (test-file "templates")
+                                 :only-show-errors true
+                                 :on-failure nil
+                                 :suppress-verbose-errors true}))]
+        (is (= (count lines) 1))
+        (is (str/starts-with? (first lines) "[ERROR]")))
+      (let [lines (sort
+                   (with-stderr-lines
+                     #(api/check {:dir [(test-file "templates")]
+                                  :include-regex ["broken.mustache$" "hello.mustache$"]
+                                  :on-failure nil
+                                  :suppress-verbose-errors true})))]
+        (is (= [(str "Checking template " (test-file "templates/broken.mustache"))
+                (str "Checking template " (test-file "templates/hello.mustache"))]
+               (butlast lines)))
+        (is (str/starts-with? (last lines) "[ERROR]")))
+      (is (= [(str "Checking template " (test-file "templates/hello.mustache"))
+              (str "Checking template " (test-file "templates/main.mustache"))]
+             (sort
+              (with-stderr-lines
+                #(api/check {:dir (test-file "templates")
+                             :exclude-regex "(broken|demo|node).mustache$"}))))))))

--- a/test/pogonos/test_runner.cljc
+++ b/test/pogonos/test_runner.cljc
@@ -1,6 +1,7 @@
 (ns pogonos.test-runner
   (:require [clojure.test :as t]
             pogonos.spec-test
+            #?(:clj pogonos.api-test)
             pogonos.core-test
             pogonos.output-test
             pogonos.parse-test
@@ -11,6 +12,7 @@
 
 (defn -main []
   (t/run-tests 'pogonos.spec-test
+               #?(:clj 'pogonos.api-test)
                'pogonos.core-test
                'pogonos.output-test
                'pogonos.parse-test


### PR DESCRIPTION
It would be useful to be able to call some of the functions from the CLI via the `-X`/`-T` options.

This PR exposes the following two features as such an API:

- `render`: Renders the given template
- `check`: Checks one or more templates