### PR TITLE
Fix incomplete error messages

### DIFF
--- a/src/pogonos/protocols.cljc
+++ b/src/pogonos/protocols.cljc
@@ -3,6 +3,7 @@
 
 (defprotocol IReader
   (read-line [this])
+  (end? [this])
   (close [this]))
 
 (defprotocol ToReader

--- a/test/pogonos/reader_test.cljc
+++ b/test/pogonos/reader_test.cljc
@@ -191,4 +191,4 @@
       (is (not (reader/blank-trailing? r)))
       (reader/read-line r)
       (is (= "baz" (reader/read-until r "|")))
-      (is (reader/blank-trailing? r)))))
+      (is (not (reader/blank-trailing? r))))))


### PR DESCRIPTION
Fixes #9.

The issue is caused by the fact that `blank-trailing?` (and `end?`) possibly read the next line, which may lead to overwriting the current line with `nil`.

The detailed changes are:
- Prevent `blank-trailing?`/`end?` from reading the next line when they are called at the end of the line
- Make `blank-trailing?` return a falsy value at the end of the input source