### PR TITLE
Fix incomplete error messages for comment tags

### DIFF
--- a/test/pogonos/parse_test.cljc
+++ b/test/pogonos/parse_test.cljc
@@ -201,6 +201,8 @@
                                  nil
                                  (catch #?(:clj Exception :cljs :default) e
                                    (::error/type (ex-data e)))))
+      "{{!" :missing-closing-delimiter
+      "{{!\n" :missing-closing-delimiter
       "{{! comment" :missing-closing-delimiter
       "{{! comment\n" :missing-closing-delimiter))
   (testing "partials"

--- a/test/pogonos/reader_test.cljc
+++ b/test/pogonos/reader_test.cljc
@@ -20,9 +20,13 @@
     (is (nil? (proto/read-line r))))
   (let [r (reader/make-string-reader "foo\nbar\nbaz")]
     (is (= "foo\n" (proto/read-line r)))
+    (is (not (proto/end? r)))
     (is (= "bar\n" (proto/read-line r)))
+    (is (not (proto/end? r)))
     (is (= "baz" (proto/read-line r)))
-    (is (nil? (proto/read-line r))))
+    (is (proto/end? r))
+    (is (nil? (proto/read-line r)))
+    (is (proto/end? r)))
   (let [r (reader/make-string-reader "foo\nbar\nbaz\n")]
     (is (= "foo\n" (proto/read-line r)))
     (is (= "bar\n" (proto/read-line r)))
@@ -50,9 +54,13 @@
        (is (nil? (proto/read-line r))))
      (with-open [r (make-file-reader "foo\nbar\nbaz")]
        (is (= "foo\n" (proto/read-line r)))
+       (is (not (proto/end? r)))
        (is (= "bar\n" (proto/read-line r)))
+       (is (not (proto/end? r)))
        (is (= "baz" (proto/read-line r)))
-       (is (nil? (proto/read-line r))))
+       (is (proto/end? r))
+       (is (nil? (proto/read-line r)))
+       (is (proto/end? r)))
      (with-open [r (make-file-reader "foo\nbar\nbaz\n")]
        (is (= "foo\n" (proto/read-line r)))
        (is (= "bar\n" (proto/read-line r)))


### PR DESCRIPTION
Similar to #14, there are still some cases where detailed error messages won't shown for comment tags:

```clojure
;; Expected

(pg/parse-string "{{!")
;; Execution error (ExceptionInfo) at pogonos.error/error (error.cljc:52).
;; Missing closing delimiter "}}" for comment tag (1:4):
;;
;;   1| {{!
;;         ^^


;; Actual

(pg/parse-string "{{!")
;; Execution error (ExceptionInfo) at pogonos.error/error (error.cljc:52).
;; Missing closing delimiter "}}" for comment tag
```

This PR fixes the issue by tweaking the code that parses comment tags and the reader code that checks if the input source is `end?`.