### PR TITLE
Allow non-map values as top-level data for spec testing

### DIFF
--- a/test/pogonos/spec_test_macros.clj
+++ b/test/pogonos/spec_test_macros.clj
@@ -6,14 +6,15 @@
             [pogonos.core :as pogonos]))
 
 (defn- expand-spec-test [{:keys [desc expected template data partials]}]
-  (let [data' (reduce-kv (fn [m k v]
-                           (assoc m k
-                                  (if (and (map? v)
-                                           (= (:__tag__ v) "code"))
-                                    (read-string (str "(do " (:clojure v) ")"))
-                                    v)))
-                         {}
-                         data)]
+  (let [data' (cond->> data
+                (map? data)
+                (reduce-kv (fn [m k v]
+                             (assoc m k
+                                    (if (and (map? v)
+                                             (= (:__tag__ v) "code"))
+                                      (read-string (str "(do " (:clojure v) ")"))
+                                      v)))
+                           {}))]
    `(t/testing ~desc
       (t/is
        (= ~expected


### PR DESCRIPTION
The latest test suite for specification conformance includes test cases where the top-level data is not a map. The current implementation of the test generation macro does not expect such cases and so results in an error, like the following:

```
Unexpected error (ClassCastException) macroexpanding clojure.test/deftest at (pogonos/spec_test.cljc:7:1).
class java.lang.Character cannot be cast to class java.util.Map$Entry (java.lang.Character and java.util.Map$Entry are in module java.base of loader 'bootstrap')
```

This PR modifies the test generation macro so that such test cases do not throw.