### PR TITLE
Support for dynamic partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pogonos is another Clojure(Script) implementation of the [Mustache](http://musta
 
 ## Features
 
-- Completely compliant to the [Mustache spec](https://github.com/mustache/spec), including lambdas
+- Compliant to the [Mustache spec](https://github.com/mustache/spec) v1.3.0 including lambdas and dynamic partials
 - Fast but clean implementation
 - User-friendly error messages for parsing errors
 - Handy API for use from the CLI

--- a/src/pogonos/nodes.cljc
+++ b/src/pogonos/nodes.cljc
@@ -21,6 +21,8 @@
 
 (defrecord Partial [name indent])
 
+(defrecord DynamicPartial [keys indent])
+
 (defrecord Comment [body]
   IVisibility
   (visible? [_] false))

--- a/src/pogonos/stringify.cljc
+++ b/src/pogonos/stringify.cljc
@@ -4,8 +4,8 @@
             [pogonos.output :as output])
   #?(:clj
      (:import [pogonos.nodes
-               Comment Inverted Partial Section SectionEnd SetDelimiter
-               UnescapedVariable Variable])))
+               Comment DynamicPartial Inverted Partial Section SectionEnd
+               SetDelimiter UnescapedVariable Variable])))
 
 (def ^:dynamic *open-delim*)
 (def ^:dynamic *close-delim*)
@@ -75,6 +75,15 @@
     (out *open-delim*)
     (out ">")
     (out (name (:name this)))
+    (out *close-delim*)
+    (when-let [post (:post (meta this))]
+      (out post)))
+
+  #?(:clj DynamicPartial :cljs nodes/DynamicPartial)
+  (stringify [this out]
+    (out *open-delim*)
+    (out ">*")
+    (stringify-keys (:keys this) out)
     (out *close-delim*)
     (when-let [post (:post (meta this))]
       (out post)))

--- a/test/pogonos/render_test.cljc
+++ b/test/pogonos/render_test.cljc
@@ -170,4 +170,35 @@
     - name: baz
       children:
   - name: bar2
+    children:"))
+  (testing "dynamic partials"
+    (are [template ctx partials expected]
+        (= expected (render template ctx partials))
+      ["[" (nodes/->DynamicPartial [:partial] nil) "]"]
+      {:partial "foo" :x 42}
+      {:foo "{{x}}"}
+      "[42]"
+
+      ["\\\n " (nodes/->DynamicPartial [:partial] " ") "\n/"]
+      {:partial :p}
+      {:p "|\n  {{>q}}\n\n|"
+       :q "]"}
+      "\\\n |\n   ]\n |\n/"
+
+      [(nodes/->DynamicPartial [:partial] nil)]
+      {:partial 'p
+       :name "foo"
+       :children
+       [{:name "bar1"
+         :children [{:name "baz" :children []}]}
+        {:name "bar2"
+         :children []}]}
+      {:p "- name: {{name}}\n  children:{{#children}}\n  {{>*partial}}\n{{/children}}"}
+      "- name: foo
+  children:
+  - name: bar1
+    children:
+    - name: baz
+      children:
+  - name: bar2
     children:")))

--- a/test/pogonos/spec_test_macros.clj
+++ b/test/pogonos/spec_test_macros.clj
@@ -29,5 +29,8 @@
 (defmacro import-spec-tests []
   `(do ~@(for [file (->> (io/file (io/resource "mustache-spec/specs"))
                          file-seq
-                         (filter #(str/ends-with? (.getName %) ".json")))]
+                         (filter #(str/ends-with? (.getName %) ".json"))
+                         ;; currently, inheritance is not supported
+                         ;; so exclude test cases for that feature for now
+                         (remove #(= (.getName %) "~inheritance.json")))]
            (expand-spec-tests file))))

--- a/test/pogonos/stringify_test.cljc
+++ b/test/pogonos/stringify_test.cljc
@@ -71,6 +71,37 @@
         (nodes/->Partial :x "  ")
         {:post "  \n"})
       "<%>x%>  \n"))
+  (testing "dynamic partials"
+    (are [input expected] (= expected (stringify input))
+      (nodes/->DynamicPartial [:x] nil) "{{>*x}}"
+      (nodes/->DynamicPartial [:x] "") "{{>*x}}"
+      (nodes/->DynamicPartial [:x] " ") "{{>*x}}"
+      (nodes/->DynamicPartial [:x :y] nil) "{{>*x.y}}"
+      (nodes/->DynamicPartial [:x :y :z] nil) "{{>*x.y.z}}"
+      (with-meta
+        (nodes/->DynamicPartial [:x] nil)
+        {:post "  \n"})
+      "{{>*x}}  \n"
+
+      (with-meta
+        (nodes/->DynamicPartial [:x :y] "  ")
+        {:post "  \n"})
+      "{{>*x.y}}  \n")
+    (are [input expected] (= expected (stringify input "<%" "%>"))
+      (nodes/->DynamicPartial [:x] nil) "<%>*x%>"
+      (nodes/->DynamicPartial [:x] "") "<%>*x%>"
+      (nodes/->DynamicPartial [:x] " ") "<%>*x%>"
+      (nodes/->DynamicPartial [:x :y] nil) "<%>*x.y%>"
+      (nodes/->DynamicPartial [:x :y :z] nil) "<%>*x.y.z%>"
+      (with-meta
+        (nodes/->DynamicPartial [:x] nil)
+        {:post "  \n"})
+      "<%>*x%>  \n"
+
+      (with-meta
+        (nodes/->DynamicPartial [:x :y] "  ")
+        {:post "  \n"})
+      "<%>*x.y%>  \n"))
   (testing "comments"
     (are [input expected] (= expected (stringify input))
       (nodes/->Comment []) "{{!}}"


### PR DESCRIPTION
Mustache [v1.3.0](https://github.com/mustache/spec/releases/tag/v1.3.0) introduced [dynamic partials](https://github.com/mustache/spec/pull/134).

*Dynamic partials* are a variant of partials that determine which file to load depending on the data passed at rendering time.

This PR adds support for dynamic partials. It also updates the Mustache spec compliance test suite to the latest.