### PR TITLE
Ignore :uninitialized-var linter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:ignore [:uninitialized-var]}


### PR DESCRIPTION
[Now the `:uninitialized-var` linter is enabled by default](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md#20230518), but it's a little bit too noisy for dynamic vars used here and there in this project, so I'm switching it off.