### PR TITLE
Fix misuse of with-open

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,2 @@
-{:ignore [:uninitialized-var]}
+{:ignore [:uninitialized-var]
+ :lint-as {pogonos.reader/with-open clojure.core/with-open}}

--- a/src/pogonos/api.clj
+++ b/src/pogonos/api.clj
@@ -99,7 +99,7 @@
       (when (and (not (:quiet opts)) (not (:only-show-errors opts)))
         (binding [*out* *err*]
           (println "Checking template" name)))
-      (with-open [r (reader/->reader input)]
+      (reader/with-open [r (reader/->reader input)]
         (with-error-handling opts
           #(pg/check-input r (assoc opts :source name)))))))
 

--- a/src/pogonos/core.cljc
+++ b/src/pogonos/core.cljc
@@ -66,7 +66,7 @@
       (let [f (io/as-file file)]
         (if (.exists f)
           (let [opts (fixup-options opts partials/file-partials)]
-            (with-open [in (reader/make-file-reader f)]
+            (reader/with-open [in (reader/make-file-reader f)]
               (parse-input in opts)))
           (throw (FileNotFoundException. (.getName f))))))))
 
@@ -81,7 +81,7 @@
      ([res opts]
       (if-let [res (io/resource res)]
         (let [opts (fixup-options opts partials/resource-partials)]
-          (with-open [in (reader/make-file-reader res)]
+          (reader/with-open [in (reader/make-file-reader res)]
             (parse-input in opts)))
         (throw (FileNotFoundException. res))))))
 
@@ -141,7 +141,7 @@
           (let [opts (-> opts
                          (fixup-options partials/file-partials)
                          (assoc :source (.getName f)))]
-            (with-open [in (reader/make-file-reader f)]
+            (reader/with-open [in (reader/make-file-reader f)]
               (render-input in data opts)))
           (throw (FileNotFoundException. (.getName f))))))))
 
@@ -157,7 +157,7 @@
       (if-let [res (io/resource res)]
         (let [opts (cond-> (fixup-options opts partials/resource-partials)
                      (string? res) (assoc :source res))]
-          (with-open [in (reader/make-file-reader res)]
+          (reader/with-open [in (reader/make-file-reader res)]
             (render-input in data opts)))
         (throw (FileNotFoundException. res))))))
 
@@ -191,7 +191,7 @@ the available options."
      ([file opts]
       (let [f (io/as-file file)]
         (if (.exists f)
-          (with-open [in (reader/make-file-reader f)]
+          (reader/with-open [in (reader/make-file-reader f)]
             (check-input in (assoc opts :source (.getName f))))
           (throw (FileNotFoundException. (.getName f))))))))
 
@@ -206,7 +206,7 @@ the available options."
      ([res opts]
       (if-let [res (io/resource res)]
         (let [opts (cond-> opts (string? res) (assoc :source res))]
-          (with-open [in (reader/make-file-reader res)]
+          (reader/with-open [in (reader/make-file-reader res)]
             (check-input in opts)))
         (throw (FileNotFoundException. res))))))
 

--- a/src/pogonos/reader.cljc
+++ b/src/pogonos/reader.cljc
@@ -1,5 +1,5 @@
 (ns pogonos.reader
-  (:refer-clojure :exclude [read-line])
+  (:refer-clojure :exclude [with-open read-line])
   (:require [clojure.string :as str]
             #?(:clj [clojure.java.io :as io])
             [pogonos.protocols :as proto]
@@ -203,3 +203,11 @@
     (when (< (col-num reader) (count line))
       (every? #{\space \tab \return \newline}
               (subs line (col-num reader))))))
+
+#?(:clj
+   (defmacro with-open [[name init] & body]
+     `(let [~name ~init]
+        (try
+          ~@body
+          (finally
+            (close ~name))))))

--- a/test/pogonos/reader_test.cljc
+++ b/test/pogonos/reader_test.cljc
@@ -41,18 +41,18 @@
 
 #?(:clj
    (deftest file-reader-test
-     (with-open [r (make-file-reader "")]
+     (reader/with-open [r (make-file-reader "")]
        (is (nil? (proto/read-line r))))
-     (with-open [r (make-file-reader "foo")]
+     (reader/with-open [r (make-file-reader "foo")]
        (is (= "foo" (proto/read-line r)))
        (is (nil? (proto/read-line r))))
-     (with-open [r (make-file-reader "\n")]
+     (reader/with-open [r (make-file-reader "\n")]
        (is (= "\n" (proto/read-line r)))
        (is (nil? (proto/read-line r))))
-     (with-open [r (make-file-reader "foo\n")]
+     (reader/with-open [r (make-file-reader "foo\n")]
        (is (= "foo\n" (proto/read-line r)))
        (is (nil? (proto/read-line r))))
-     (with-open [r (make-file-reader "foo\nbar\nbaz")]
+     (reader/with-open [r (make-file-reader "foo\nbar\nbaz")]
        (is (= "foo\n" (proto/read-line r)))
        (is (not (proto/end? r)))
        (is (= "bar\n" (proto/read-line r)))
@@ -61,7 +61,7 @@
        (is (proto/end? r))
        (is (nil? (proto/read-line r)))
        (is (proto/end? r)))
-     (with-open [r (make-file-reader "foo\nbar\nbaz\n")]
+     (reader/with-open [r (make-file-reader "foo\nbar\nbaz\n")]
        (is (= "foo\n" (proto/read-line r)))
        (is (= "bar\n" (proto/read-line r)))
        (is (= "baz\n" (proto/read-line r)))


### PR DESCRIPTION
The root cause of #35 seems to be the fact that even after adding the `IReader` protocol's own `close` method in 8519c72 instead of `Closeable#close`, some code has been using `with-open` to close the `IReader` implementation as before by mistake.

This PR fixes those misuses of `with-open`.