### PR TITLE
Exit with non-zero on test failure

### DIFF
--- a/test/pogonos/test_runner.cljc
+++ b/test/pogonos/test_runner.cljc
@@ -10,13 +10,28 @@
             pogonos.render-test
             pogonos.stringify-test))
 
+(defn- exit-with [{:keys [fail error]}]
+  (let [succeeded? (zero? (+ fail error))]
+    #?(:clj (System/exit (if succeeded? 0 1))
+     :cljs (when-not succeeded?
+             (throw (ex-info "Tests failed" {:fail fail :error error}))))))
+
+#?(:cljs
+   (defmethod t/report [::t/default :end-run-tests] [summary]
+     (exit-with summary)))
+
+(defn- clean-up [m]
+  #?(:clj (exit-with m)
+     :cljs m))
+
 (defn -main []
-  (t/run-tests 'pogonos.spec-test
-               #?(:clj 'pogonos.api-test)
-               'pogonos.core-test
-               'pogonos.output-test
-               'pogonos.parse-test
-               'pogonos.partials-test
-               'pogonos.reader-test
-               'pogonos.render-test
-               'pogonos.stringify-test))
+  (clean-up
+   (t/run-tests 'pogonos.spec-test
+                #?(:clj 'pogonos.api-test)
+                'pogonos.core-test
+                'pogonos.output-test
+                'pogonos.parse-test
+                'pogonos.partials-test
+                'pogonos.reader-test
+                'pogonos.render-test
+                'pogonos.stringify-test)))


### PR DESCRIPTION
As mentioned in #35, the current tests won't exit with non-zero even if some tests fail.

This PR fixes the test runner to exit with non-zero on test failure.